### PR TITLE
Fix API endpoints to use relative paths

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 // Example: Test backend connectivity
 async function testBackendConnection() {
     try {
-        const response = await fetch("http://localhost:8000/api/health", {
+        const response = await fetch("/api/health", {
             method: "GET",
         });
         const data = await response.json();

--- a/index.html
+++ b/index.html
@@ -1766,7 +1766,9 @@
       // CONSTANTS AND STATE
       // ========================
 
-      const API_BASE = "http://localhost:8000";
+      // Use relative API base so the frontend works behind reverse proxies
+      // or when the backend runs on a different host/port.
+      const API_BASE = "/api";
       const QUANTUM_LEVELS = [
         "Quantum Novice",
         "Temporal Explorer",


### PR DESCRIPTION
## Summary
- use relative `/api` prefix for frontend API requests in index.html
- fix health check fetch to use relative path in app.js

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579991871c8328ae7ce52409fe932b