### PR TITLE
Fix API endpoints to use relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# db
+# QuantumVault Demo
+
+This project includes a minimal FastAPI backend and a static frontend. The
+backend connects to MongoDB using the `MONGODB_URL` environment variable.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start MongoDB (or use Docker compose):
+   ```bash
+   docker-compose up mongodb
+   ```
+3. Run the API server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+4. Open `index.html` in a browser to use the frontend.
+
+The `/api/health` endpoint checks database connectivity and the `/api/users`
+endpoint lists users from the `users` collection.

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 // Example: Test backend connectivity
 async function testBackendConnection() {
     try {
-        const response = await fetch("http://localhost:8000/api/health", {
+        const response = await fetch("/api/health", {
             method: "GET",
         });
         const data = await response.json();

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,24 @@
+import os
+from fastapi import FastAPI
+from motor.motor_asyncio import AsyncIOMotorClient
+
+app = FastAPI()
+
+MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017/quantum_dashboard")
+client = AsyncIOMotorClient(MONGODB_URL)
+db = client.get_default_database()
+
+@app.get("/api/health")
+async def health_check():
+    try:
+        await client.admin.command("ping")
+        return {"status": "ok"}
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)}
+
+@app.get("/api/users")
+async def list_users():
+    users = await db["users"].find().to_list(length=100)
+    for user in users:
+        user["_id"] = str(user["_id"])
+    return {"users": users}

--- a/index.html
+++ b/index.html
@@ -1766,7 +1766,9 @@
       // CONSTANTS AND STATE
       // ========================
 
-      const API_BASE = "http://localhost:8000";
+      // Use relative API base so the frontend works behind reverse proxies
+      // or when the backend runs on a different host/port.
+      const API_BASE = "/api";
       const QUANTUM_LEVELS = [
         "Quantum Novice",
         "Temporal Explorer",


### PR DESCRIPTION
## Summary
- use relative `/api` prefix for frontend API requests in index.html
- fix health check fetch to use relative path in app.js
- add simple FastAPI backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579991871c8328ae7ce52409fe932b